### PR TITLE
Fix dependencies

### DIFF
--- a/tools/cluster_profiler/cluster_profiler.xml
+++ b/tools/cluster_profiler/cluster_profiler.xml
@@ -1,4 +1,4 @@
-<tool id="cluter_profiler" name="GO terms classification and enrichment analysis" version="2019.06.27.1">
+<tool id="cluter_profiler" name="GO terms classification and enrichment analysis" version="2019.09.26">
     <description>(Human, Mouse, Rat)[clusterProfiler]</description>
     <requirements>
         <requirement type="package">R</requirement>

--- a/tools/cluster_profiler/cluster_profiler.xml
+++ b/tools/cluster_profiler/cluster_profiler.xml
@@ -1,12 +1,12 @@
 <tool id="cluter_profiler" name="GO terms classification and enrichment analysis" version="2019.06.27.1">
     <description>(Human, Mouse, Rat)[clusterProfiler]</description>
     <requirements>
-        <requirement type="package" version="3.4.1">R</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.hs.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.mm.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.Rn.eg.db</requirement>
-        <requirement type="package" version="3.2.0">bioconductor-dose</requirement>
-        <requirement type="package" version="3.4.4">bioconductor-clusterprofiler</requirement>
+        <requirement type="package">R</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.mm.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.Rn.eg.db</requirement>
+        <requirement type="package" version="3.10.2">bioconductor-dose</requirement>
+        <requirement type="package" version="3.12.0">bioconductor-clusterprofiler</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         Rscript "$__tool_directory__/GO-enrich.R"
@@ -19,7 +19,7 @@
             --ncol="$input.ncol"
             --header="$input.header"
         #end if
-        
+
         --id_type="$idti.idtypein"
 
         --species="$species"
@@ -32,7 +32,7 @@
         #end if
 
         #if $ego.go_enrich == "true"
-            --plot="$ego.plot" 
+            --plot="$ego.plot"
             --go_enrich="true"
             --pval_cutoff="$ego.pval"
             --qval_cutoff="$ego.qval"
@@ -51,7 +51,7 @@
         #else
             --go_enrich="false"
         #end if
-        
+
         --onto_opt="$ontology" > $log
     ]]></command>
     <inputs>
@@ -87,7 +87,7 @@
             </param>
             <when value="Uniprot"/>
             <when value="Entrez"/>
-        </conditional>   
+        </conditional>
         <param name="species" type="select" label="Species" >
             <option value="org.Hs.eg.db">Human (Homo sapiens) </option>
             <option value="org.Mm.eg.db">Mouse (Mus musculus) </option>
@@ -226,11 +226,11 @@
 
 This tool is based on R package clusterProfiler and allows to perform GO terms classification and enrichment analyses on gene/protein sets (e.g. given a set of genes that are up-regulated under certain conditions, an enrichment analysis will find which GO terms are over-represented (or under-represented) using annotations for that gene/protein set).
 
-Given a list of IDs, this tool: 
+Given a list of IDs, this tool:
 
 (i)  performs gene classification based on GO distribution at a specific level,
-  
-(ii) calculates GO categories enrichment (over- or under-representation) for the IDs of the input list, compared to a background. User has the possibility to use background corresponding to the whole organism or to a user-defined list. In this latter case, we recommand to use the "Build tissue-specific expression dataset" ProteoRE tool to create this list according to your need. 
+
+(ii) calculates GO categories enrichment (over- or under-representation) for the IDs of the input list, compared to a background. User has the possibility to use background corresponding to the whole organism or to a user-defined list. In this latter case, we recommand to use the "Build tissue-specific expression dataset" ProteoRE tool to create this list according to your need.
 
 -----
 
@@ -238,17 +238,17 @@ Given a list of IDs, this tool:
 
 Two modes are allowed: either by supplying a tabular file (.csv, .tsv, .txt, .tab) including your IDs (identifiers) or by copy/pasting your IDs (separated by a space).
 
-"Select type/source of IDs": only entrez gene ID (e.g. 4151, 7412) or Uniprot accession number (e.g. P31946) are allowed. If your list is not in this form, please use the ID_Converter tool of ProteoRE. 
+"Select type/source of IDs": only entrez gene ID (e.g. 4151, 7412) or Uniprot accession number (e.g. P31946) are allowed. If your list is not in this form, please use the ID_Converter tool of ProteoRE.
 
 .. class:: warningmark
-	
+
 In copy/paste mode, the number of IDs considered in input is limited to 5000.
 
 -----
 
 **Parameters**
 
-"Species": the three supported species are Homo sapiens, Mus musculus and Rattus norvegicus 
+"Species": the three supported species are Homo sapiens, Mus musculus and Rattus norvegicus
 
 "Perform GO categories representation analysis?": classify genes based on their projection at a specific level of the GO corpus (see parameter below), and provides functions (set to "Yes")
 
@@ -260,24 +260,24 @@ In copy/paste mode, the number of IDs considered in input is limited to 5000.
 
 "Q-value cut off": to prevent high false discovery rate (FDR) in multiple testing, Q-values (adjusted P-values) are estimated for FDR control. (default is < 0.05)
 
-"Define your own background IDs?": by default the whole genome/proteome is used as a reference background to compute the enrichment. As this reference set should normally only include genes/proteins that were monitored during your analysis, this option allows to provide your own background; this could be for instance, the total number of genes/proteins expressed in the tissue/sample under study. 
+"Define your own background IDs?": by default the whole genome/proteome is used as a reference background to compute the enrichment. As this reference set should normally only include genes/proteins that were monitored during your analysis, this option allows to provide your own background; this could be for instance, the total number of genes/proteins expressed in the tissue/sample under study.
 
-If you want to use your own background, click on the "Yes" button. Your gene/protein set must be a list of Entrez gene ID or Uniprot accession number (otherwise, use the ID-Converter tool of ProteoRE). Select the file containing your list of ID (as background), then specify the column number which contains IDs and the type of IDs (gene Entrez or Uniprot Accession number) as requested. 
+If you want to use your own background, click on the "Yes" button. Your gene/protein set must be a list of Entrez gene ID or Uniprot accession number (otherwise, use the ID-Converter tool of ProteoRE). Select the file containing your list of ID (as background), then specify the column number which contains IDs and the type of IDs (gene Entrez or Uniprot Accession number) as requested.
 
 Of note: for Human species, you can build your own background by using the "Build tissue-specific expression dataset" tool of ProteoRE.
 
------ 
+-----
 
 **Output**
 
-Diagram output: graphical output in the form of bar-plot or dot-plot (png, jpeg or pdf format), one figure for each GO category. 
-Text tables: with the following information GO category description (e.g.BP.Description), GO term identifier (e.g. BP.GOID) and GO term frequency (e.g. BP.Frequency)d graphics representing the repartition and/or enrichment of GO categories. One table and one graphic will be produced for each GO catagory. 
+Diagram output: graphical output in the form of bar-plot or dot-plot (png, jpeg or pdf format), one figure for each GO category.
+Text tables: with the following information GO category description (e.g.BP.Description), GO term identifier (e.g. BP.GOID) and GO term frequency (e.g. BP.Frequency)d graphics representing the repartition and/or enrichment of GO categories. One table and one graphic will be produced for each GO catagory.
 
 -----
 
 **Authors**
 
-G Yu, LG Wang, Y Han, QY He. clusterProfiler: an R package for comparing biological themes among gene clusters. 
+G Yu, LG Wang, Y Han, QY He. clusterProfiler: an R package for comparing biological themes among gene clusters.
 OMICS: A Journal of Integrative Biology 2012, 16(5):284-287. doi:[10.1089/omi.2011.0118](http://dx.doi.org/10.1089/omi.2011.0118)
 
 User manual / Documentation of the clusterProfiler R package (functions and parameters):
@@ -287,13 +287,13 @@ https://bioconductor.org/packages/3.7/bioc/vignettes/clusterProfiler/inst/doc/cl
 
 .. class:: infomark
 
-Bioconductor Packages used: 
+Bioconductor Packages used:
 
-    - bioconductor-org.hs.eg.db v3.5.0
-    - bioconductor-org.mm.eg.db v3.5.0
-    - bioconductor-org.rn.eg.db v3.5.0
-    - dose v3.2.0
-    - clusterprofiler v 3.4.4
+    - bioconductor-org.hs.eg.db v3.8.2
+    - bioconductor-org.mm.eg.db v3.8.2
+    - bioconductor-org.rn.eg.db v3.8.2
+    - dose v3.10.2
+    - clusterprofiler v 3.12.0
 
 .. class:: infomark
 

--- a/tools/goprofiles/goprofiles.xml
+++ b/tools/goprofiles/goprofiles.xml
@@ -2,12 +2,12 @@
     <description>(Human, Mouse) [goProfiles]</description>
     <requirements>
         <requirement type="package" >R</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.hs.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.mm.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.mm.eg.db</requirement>
         <!--requirement type="package" version="3.5.0">bioconductor-org.rn.eg.db</requirement-->
-        <requirement type="package" version="1.40.0">bioconductor-annotationdbi</requirement>
-        <requirement type="package" version="2.38.0">bioconductor-biobase</requirement>
-        <requirement type="package" version="1.44.0">bioconductor-goprofiles</requirement>
+        <requirement type="package" version="1.46.0">bioconductor-annotationdbi</requirement>
+        <requirement type="package" version="2.44.0">bioconductor-biobase</requirement>
+        <requirement type="package" version="1.46.0">bioconductor-goprofiles</requirement>
 
     </requirements>
     <stdio>

--- a/tools/goprofiles/goprofiles.xml
+++ b/tools/goprofiles/goprofiles.xml
@@ -2,7 +2,7 @@
     <description>(Human, Mouse) [goProfiles]</description>
     <requirements>
         <requirement type="package" >R</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.8.2">-org.hs.eg.db</requirement>
         <requirement type="package" version="3.8.2">bioconductor-org.mm.eg.db</requirement>
         <!--requirement type="package" version="3.5.0">bioconductor-org.rn.eg.db</requirement-->
         <requirement type="package" version="1.46.0">bioconductor-annotationdbi</requirement>

--- a/tools/goprofiles/goprofiles.xml
+++ b/tools/goprofiles/goprofiles.xml
@@ -7,7 +7,7 @@
         <!--requirement type="package" version="3.5.0">bioconductor-org.rn.eg.db</requirement-->
         <requirement type="package" version="1.40.0">bioconductor-annotationdbi</requirement>
         <requirement type="package" version="2.38.0">bioconductor-biobase</requirement>
-        <requirement type="package" version="1.44.0">bioconductor-goprofile</requirement>
+        <requirement type="package" version="1.44.0">bioconductor-goprofiles</requirement>
 
     </requirements>
     <stdio>

--- a/tools/goprofiles/goprofiles.xml
+++ b/tools/goprofiles/goprofiles.xml
@@ -1,14 +1,14 @@
 <tool id="goProfiles" name="Statistical analysis of functional profiles" version="2019.06.27">
     <description>(Human, Mouse) [goProfiles]</description>
-    <requirements> 
-        <requirement type="package" version="3.4.1">R</requirement>
+    <requirements>
+        <requirement type="package" >R</requirement>
         <requirement type="package" version="3.5.0">bioconductor-org.hs.eg.db</requirement>
         <requirement type="package" version="3.5.0">bioconductor-org.mm.eg.db</requirement>
         <!--requirement type="package" version="3.5.0">bioconductor-org.rn.eg.db</requirement-->
         <requirement type="package" version="1.40.0">bioconductor-annotationdbi</requirement>
         <requirement type="package" version="2.38.0">bioconductor-biobase</requirement>
-        <requirement type="package" version="1.38.0">goprofiles</requirement>
-        
+        <requirement type="package" version="1.44.0">bioconductor-goprofile</requirement>
+
     </requirements>
     <stdio>
         <exit_code range="1:" />
@@ -24,7 +24,7 @@
             --ncol="$input.ncol"
             --header="$input.header"
         #end if
-        
+
         --id_type="$input.id_type"
         --onto_opt="$onto_opt"
         --plot_opt="$plot_opt"
@@ -68,7 +68,7 @@
                     <option value="Entrez">Entrez Gene ID</option>
                     <option value="UniProt">Uniprot Accession number</option>
                 </param>
-            </when>            
+            </when>
         </conditional>
         <param name="duplicate" type="boolean" checked="true" label="Remove duplicated IDs" truevalue="TRUE" falsevalue="FALSE" />
         <param name="species" type="select" label="Species">
@@ -97,7 +97,7 @@
                     <remove value="/"/>
                 </valid>
                 <mapping>
-                    <add source="&#x20;" target=""/> 
+                    <add source="&#x20;" target=""/>
                 </mapping>
             </sanitizer>
         </param>
@@ -125,8 +125,8 @@
                 <param name="ids" value="file" />
                 <param name="file" value="ID_Converted_FKW_Lacombe_et_al_2017_OK.txt" />
                 <param name="ncol" value="c1" />
-                <param name="header" value="true" /> 
-                <param name="id_type" value="UniProt" />              
+                <param name="header" value="true" />
+                <param name="id_type" value="UniProt" />
             </conditional>
             <param name="duplicate" value="false"/>
             <param name="onto_opt" value="CC,MF,BP" />
@@ -147,17 +147,17 @@
 **Description**
 
 This tool relies on the goProfiles R package; it performs statistical analysis of functional profiles based on Gene Ontology (GO). Functional profile at a given GO level is obtained by counting the
-number of identifiers having a hit in each category of this level.   
+number of identifiers having a hit in each category of this level.
 
 -----
 
-**Input** 
+**Input**
 
 Two modes are allowed: either by copy/pasting your IDs (separated by a space) or by supplying a tabular file (.csv, .tsv, .txt, .tab) including your IDs (identifiers).
-Only entrez gene ID (e.g. 4151) or Uniprot accession number (e.g. P31946) are allowed. If your list is not in this form, please use the ID_Converter tool of ProteoRE. 
+Only entrez gene ID (e.g. 4151) or Uniprot accession number (e.g. P31946) are allowed. If your list is not in this form, please use the ID_Converter tool of ProteoRE.
 
 .. class:: warningmark
-	
+
 In copy/paste mode, the number of IDs considered in input is limited to 5000.
 
 -----
@@ -166,7 +166,7 @@ In copy/paste mode, the number of IDs considered in input is limited to 5000.
 
 "Species": enter the sepcies you are working on; Homo sapiens and Mus musculus supported (Rattus norvegicus coming soon)
 
-"Select GO terms category": you can choose one or more GO categories which are Biological Process (BP), Cellular Component (CC) and Molecular Function (MF) 
+"Select GO terms category": you can choose one or more GO categories which are Biological Process (BP), Cellular Component (CC) and Molecular Function (MF)
 
 "Ontology level (the higher this number, the deeper the GO level)": correspond to the level of GO hierarchy (from 1 to 6). In general the higher the level, the more semantically specific the term is.
 
@@ -174,7 +174,7 @@ In copy/paste mode, the number of IDs considered in input is limited to 5000.
 
 **Ouput**
 
-Diagram output: graphical output in the form of bar-plot or dot-plot (png (default format), jpeg or pdf format), one figure for each GO category. 
+Diagram output: graphical output in the form of bar-plot or dot-plot (png (default format), jpeg or pdf format), one figure for each GO category.
 
 Text output: with the following information GO category description (e.g.BP.Description), GO term identifier (e.g. BP.GOID) and GO term frequency (e.g. BP.Frequency)
 
@@ -182,7 +182,7 @@ Text output: with the following information GO category description (e.g.BP.Desc
 
 .. class:: infomark
 
-Packages used: 
+Packages used:
     - bioconductor-org.hs.eg.db v3.5.0
     - bioconductor-org.mm.eg.db v3.5.0
     - bioconductor-annotationdbi v1.40.0
@@ -193,7 +193,7 @@ Packages used:
 
 .. class:: infomark
 
-**Authors** 
+**Authors**
 
 Salicrú M, Ocaña J, Sánchez-Pla A. Comparison of lists of genes based on functional profiles. BMC Bioinformatics. 2011. 12:401. doi:10.1186/1471-2105-12-401. PubMed PMID: 21999355
 

--- a/tools/goprofiles/goprofiles.xml
+++ b/tools/goprofiles/goprofiles.xml
@@ -1,4 +1,4 @@
-<tool id="goProfiles" name="Statistical analysis of functional profiles" version="2019.06.27">
+<tool id="goProfiles" name="Statistical analysis of functional profiles" version="2019.09.26">
     <description>(Human, Mouse) [goProfiles]</description>
     <requirements>
         <requirement type="package" >R</requirement>

--- a/tools/topGO/topGO.xml
+++ b/tools/topGO/topGO.xml
@@ -237,13 +237,13 @@ The different fields are as follow:
 .. class:: infomark
 
 Packages used:
-    - bioconductor-org.hs.eg.db v3.5.0
-    - bioconductor-org.mm.eg.db v3.5.0
-    - bioconductor-org.rn.eg.db v3.5.0
-    - bioconductor-annotationdbi v1.40.0
-    - bioconductor-go.db v3.5.0
-    - bioconductor-graph v1.56.0
-    - bioconductor-topgo v2.30.0
+    - bioconductor-org.hs.eg.db v3.8.2
+    - bioconductor-org.mm.eg.db v3.8.2
+    - bioconductor-org.rn.eg.db v3.8.2
+    - bioconductor-annotationdbi v1.46.0
+    - bioconductor-go.db v3.8.2
+    - bioconductor-graph v1.62.0
+    - bioconductor-topgo v2.36.0
 
 -----
 

--- a/tools/topGO/topGO.xml
+++ b/tools/topGO/topGO.xml
@@ -1,26 +1,26 @@
-<tool id="topGO" name="Enrichment analysis for Gene Ontology" version="2019.06.27">
+<tool id="topGO" name="Enrichment analysis for Gene Ontology" version="2019.09.26">
     <description>(Human, Mouse, Rat)[topGO]</description>
     <requirements>
-        <requirement type="package" version="3.4.1">R</requirement>
-        <requirement type="package" version="3.0.0">r-ggplot2</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.hs.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.mm.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.rn.eg.db</requirement>
+        <requirement type="package">R</requirement>
+        <requirement type="package">r-ggplot2</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.mm.eg.db</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-org.rn.eg.db</requirement>
         <!--requirement type="package" version="3.6.0">bioconductor-org.ce.eg.db</requirement-->
         <!--requirement type="package" version="3.6.0">bioconductor-org.dm.eg.db</requirement-->
         <!--requirement type="package" version="3.6.0">bioconductor-org.sc.sgd.db</requirement-->
         <!--requirement type="package" version="3.5.0">bioconductor-org.at.tair.db</requirement-->
-        <requirement type="package" version="1.56.0">bioconductor-graph</requirement>
-        <requirement type="package" version="1.40.0">bioconductor-annotationdbi</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-go.db</requirement>
-        <requirement type="package" version="2.30.0">bioconductor-topgo</requirement>
+        <requirement type="package" version="1.62.0">bioconductor-graph</requirement>
+        <requirement type="package" version="1.46.0">bioconductor-annotationdbi</requirement>
+        <requirement type="package" version="3.8.2">bioconductor-go.db</requirement>
+        <requirement type="package" version="2.36.0">bioconductor-topgo</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />
     </stdio>
     <command><![CDATA[
-       
-  Rscript --vanilla $__tool_directory__/topGO_enrichment.R 
+
+  Rscript --vanilla $__tool_directory__/topGO_enrichment.R
   --inputtype="$inputtype.filetype"
   --input='$inputtype.genelist'
 
@@ -35,7 +35,7 @@
   --correction='$correction'
   --textoutput='true'
   --plot='$plot'
-  --geneuniverse='$geneuniverse' 
+  --geneuniverse='$geneuniverse'
   --background="$background_genes.background"
 
   #if $background_genes.background == "true"
@@ -53,7 +53,7 @@
   <conditional name="inputtype">
     <param name="filetype" type="select" label="Enter your IDs (Ensembl Gene Id)" help="Copy/paste or from a file">
       <option value="file" selected="true">Input file containing your IDs</option>
-      <option value="copy_paste">Copy/paste your list of IDs</option> 
+      <option value="copy_paste">Copy/paste your list of IDs</option>
     </param>
     <when value="copy_paste">
       <param name="genelist" type="text" label="Enter a list of IDs">
@@ -70,9 +70,9 @@
     <when value="file">
       <param name="genelist" type="data" format="txt,tabular" label="Select your file" help=""/>
       <param name="column" type="text" label="Column number of IDs" help="For example, fill in 'c1' if it is the first column, 'c2' if it is the second column and so on">
-        <validator type="regex" message="Please enter a column number, for example: 'c1' for the first column">[c]{0,1}[0-9]+</validator> 
+        <validator type="regex" message="Please enter a column number, for example: 'c1' for the first column">[c]{0,1}[0-9]+</validator>
       </param>
-      <param name="header" type="boolean" checked="true" truevalue="true" falsevalue="false" label="Does file contain header?" /> 
+      <param name="header" type="boolean" checked="true" truevalue="true" falsevalue="false" label="Does file contain header?" />
     </when>
   </conditional>
   <conditional name="background_genes">
@@ -81,7 +81,7 @@
       <conditional name="inputtype">
         <param name="filetype" type="select" label="Enter your background IDs (Ensembl gene IDs)" help="(e.g : ENSG00000139618)">
           <option value="file" selected="true">Input file containing your background IDs</option>
-          <option value="copy_paste">Copy/paste your background IDs</option> 
+          <option value="copy_paste">Copy/paste your background IDs</option>
         </param>
         <when value="copy_paste">
           <param name="genelist" type="text" label="Copy/paste your background IDs" help="IDs must be separated by spaces into the form field, for example: ENSG00000139618 ENSG00000007350">
@@ -97,10 +97,10 @@
         </when>
         <when value="file">
           <param name="genelist" type="data" format="txt,tabular" label="Select file that contains your background IDs list" help=""/>
-          <param name="header" type="boolean" checked="true" truevalue="true" falsevalue="false" label="Does file contain header ?" /> 
+          <param name="header" type="boolean" checked="true" truevalue="true" falsevalue="false" label="Does file contain header ?" />
           <param name="column" type="text" label="Column number of IDs" value="c1" help="For example, fill in 'c1' if it is the first column, 'c2' if it is the second column and so on">
             <validator type="regex" message="Please enter a column number, for example: 'c1' for the first column">[c]{0,1}[0-9]+</validator>
-          </param> 
+          </param>
         </when>
       </conditional>
     </when>
@@ -156,7 +156,7 @@
       <data name="outputbarplot" format="png" label="Barplot output for topGO analysis $ontocat category" from_work_dir="barplot.png">
         <filter>'barplot' in plot</filter>
       </data>
-      
+
    </outputs>
    <tests>
      <test>
@@ -169,7 +169,7 @@
        <param name="ontocat" value="BP"/>
        <param name="option" value="elim"/>
        <param name="threshold" value="1e-3"/>
-       <param name="correction" value="BH"/> 
+       <param name="correction" value="BH"/>
        <param name="textoutput" value="TRUE"/>
        <param name="plot" value="dotplot,barplot"/>
        <param name="geneuniverse" value="org.Hs.eg.db"/>
@@ -179,8 +179,8 @@
      </test>
    </tests>
    <help><![CDATA[
-      
-      
+
+
 **Description**
 
 This tool is based on R package topGO. topGO package provides tools for testing GO terms while accounting for the topology of the GO graph. Different test statistics and different methods for eliminating local similarities and dependencies between GO terms can be applied.
@@ -192,17 +192,17 @@ This component computes the GO terms representativity of a gene list in one onto
 **Input required**
 
 This component works with Ensembl gene IDs (e.g : ENSG0000013618). You can copy/paste these identifiers or supply a tabular file (.csv, .tsv, .txt, .tab)
-and then specifying the column number that contains the ENSG IDs. 
+and then specifying the column number that contains the ENSG IDs.
 
 -----
 
 **Parameters**
 
-"Species": "Species": the three available species are Homo sapiens, Mus musculus and Rattus norvegicus 
- 
+"Species": "Species": the three available species are Homo sapiens, Mus musculus and Rattus norvegicus
+
 "GO terms category": select either Biogical Process (BP)(by default), Cellular Component (CC) or Molecular Function (MF)
- 
-"Select GO scoring method: topGO provides the commonly used Fisher test for evaluating which GO terms are over-represented in your gene/protein list; it also provides other GO scoring algorithms (i.e. Elim, Weight01, Parentchild). For the merits of each option and their algorithmic description, please refer to topGO manual: 
+
+"Select GO scoring method: topGO provides the commonly used Fisher test for evaluating which GO terms are over-represented in your gene/protein list; it also provides other GO scoring algorithms (i.e. Elim, Weight01, Parentchild). For the merits of each option and their algorithmic description, please refer to topGO manual:
 https://bioconductor.org/packages/release/bioc/vignettes/topGO/inst/doc/topGO.pdf
 
 "p-value threshold (e.g : 1e-3)": must be in the form of "1e-5" (i.e. 0.00001)
@@ -214,29 +214,29 @@ Hommel, Bonferroni, BH (Benjamini-Hochberg), BY (Benjamini-Yekutieli), FDR. Defa
 
 **Output**
 
-Two types of output are available: textual and/or graphical outputs (barplot and/or a dotplot (set by default)). 
+Two types of output are available: textual and/or graphical outputs (barplot and/or a dotplot (set by default)).
 
 *Textual output*
 
-The text output lists all the GO-terms that were found significantly enriched according to the specified threshold (p-value).    
+The text output lists all the GO-terms that were found significantly enriched according to the specified threshold (p-value).
 
 The different fields are as follow:
 
 - Annotated : number of genes in the selected species that are annotated with the GO-term.
 
-- Significant : number of genes belonging to your input annotated with the GO-term. 
+- Significant : number of genes belonging to your input annotated with the GO-term.
 
 - Expected : represents the expected number of interesting genes mapped to the GO term if the interesting genes were randomly distributed over all GO terms.
 
-- p-values : p-value obtained after the test 
+- p-values : p-value obtained after the test
 
-- ( q-values  : additional column with adjusted pvalues ) 
+- ( q-values  : additional column with adjusted pvalues )
 
 -----
 
 .. class:: infomark
 
-Packages used: 
+Packages used:
     - bioconductor-org.hs.eg.db v3.5.0
     - bioconductor-org.mm.eg.db v3.5.0
     - bioconductor-org.rn.eg.db v3.5.0


### PR DESCRIPTION
#243 goprofiles not available in bioconda :
fix wrapper to link to bioconda bioconductor-goprofiles

biconductor-goprofiles need an updated version of org-*-db  ( #244)

Tools fixed :
goprofile
topgo
clusterprofiler

